### PR TITLE
ミュートワードのインポート/エクスポート機能を追加

### DIFF
--- a/src/popup.css
+++ b/src/popup.css
@@ -69,6 +69,45 @@ main {
   margin-bottom: 16px;
 }
 
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.icon-btn {
+  width: 32px;
+  height: 32px;
+  border: none;
+  background: rgba(102, 126, 234, 0.1);
+  border-radius: 8px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.3s ease;
+  color: #667eea;
+}
+
+.icon-btn:hover {
+  background: rgba(102, 126, 234, 0.2);
+  transform: translateY(-1px);
+}
+
+.icon-btn:active {
+  transform: translateY(0);
+}
+
+.icon-btn.success {
+  background: rgba(34, 197, 94, 0.2);
+  color: #22c55e;
+}
+
+.icon-btn svg {
+  width: 16px;
+  height: 16px;
+}
+
 .toggle-all-container {
   display: flex;
   align-items: center;

--- a/src/popup.html
+++ b/src/popup.html
@@ -20,12 +20,25 @@
       <section class="mute-words-section">
         <div class="section-header">
           <h2>ミュートワード管理</h2>
-          <div class="toggle-all-container">
-            <label class="toggle-switch">
-              <input type="checkbox" id="toggle-all-words" checked>
-              <span class="toggle-slider"></span>
-            </label>
-            <span class="toggle-label">すべて有効</span>
+          <div class="header-actions">
+            <button id="export-btn" class="icon-btn" title="エクスポート">
+              <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M8 12L8 3M8 12L5 9M8 12L11 9M2 14H14" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+            </button>
+            <button id="import-btn" class="icon-btn" title="インポート">
+              <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M8 4L8 13M8 4L5 7M8 4L11 7M2 14H14" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+            </button>
+            <input type="file" id="import-file" accept=".json" style="display: none;">
+            <div class="toggle-all-container">
+              <label class="toggle-switch">
+                <input type="checkbox" id="toggle-all-words" checked>
+                <span class="toggle-slider"></span>
+              </label>
+              <span class="toggle-label">すべて有効</span>
+            </div>
           </div>
         </div>
         


### PR DESCRIPTION
## 概要
- ミュートワードのエクスポート機能を追加（JSON形式でダウンロード）
- ミュートワードのインポート機能を追加（JSONファイルから一括読み込み）
- インポート/エクスポート時の視覚的フィードバックを実装

## 変更内容
- エクスポートボタン：現在のミュートワードをJSON形式でダウンロード
- インポートボタン：JSONファイルからミュートワードを読み込んで置き換え
- インポート時のバリデーション機能
- 成功時のビジュアルフィードバック（ボタンの色変更）

## テストプラン
- [ ] エクスポートボタンをクリックしてJSONファイルがダウンロードされることを確認
- [ ] インポートボタンでJSONファイルを選択して読み込めることを確認
- [ ] 無効なJSONファイルをインポートした際にエラーメッセージが表示されることを確認
- [ ] インポート/エクスポート成功時にボタンの色が変わることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added export and import functionality for mute words, allowing users to back up and restore their mute word lists via JSON files.
	- Introduced new UI buttons for export and import actions in the mute word management section, with visual feedback on successful operations.

- **Style**
	- Updated styles for icon buttons and header actions to provide a more interactive and consistent user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->